### PR TITLE
Fix crashes if View is null when service callback methods called

### DIFF
--- a/core/src/main/java/com/joaquimley/core/ui/character/CharacterPresenter.java
+++ b/core/src/main/java/com/joaquimley/core/ui/character/CharacterPresenter.java
@@ -74,6 +74,7 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
         mDataManager.getCharacter(id, new RemoteCallback<DataWrapper<List<CharacterMarvel>>>() {
             @Override
             public void onSuccess(DataWrapper<List<CharacterMarvel>> response) {
+                if (!isViewAttached()) return;
                 mView.hideProgress();
                 if (response.getData().getResults().isEmpty()) {
                     mView.showError("Character does not exist");
@@ -85,11 +86,13 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
 
             @Override
             public void onUnauthorized() {
+                if (!isViewAttached()) return;
                 mView.showUnauthorizedError();
             }
 
             @Override
             public void onFailed(Throwable throwable) {
+                if (!isViewAttached()) return;
                 mView.showError(throwable.getMessage());
             }
         });
@@ -103,6 +106,7 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
         mDataManager.getComics(id, offset, limit, new RemoteCallback<DataWrapper<List<Comic>>>() {
             @Override
             public void onSuccess(DataWrapper<List<Comic>> response) {
+                if (!isViewAttached()) return;
                 mView.hideProgress();
                 if (response.getData().getResults().isEmpty()) {
                     mView.showError("Character has no comics");
@@ -113,11 +117,13 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
 
             @Override
             public void onUnauthorized() {
+                if (!isViewAttached()) return;
                 mView.showUnauthorizedError();
             }
 
             @Override
             public void onFailed(Throwable throwable) {
+                if (!isViewAttached()) return;
                 mView.showError(throwable.getMessage());
             }
         });
@@ -131,6 +137,7 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
         mDataManager.getSeries(id, offset, limit, new RemoteCallback<DataWrapper<List<Comic>>>() {
             @Override
             public void onSuccess(DataWrapper<List<Comic>> response) {
+                if (!isViewAttached()) return;
                 mView.hideProgress();
                 if (response.getData().getResults().isEmpty()) {
                     mView.showError("Character has no series");
@@ -141,11 +148,13 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
 
             @Override
             public void onUnauthorized() {
+                if (!isViewAttached()) return;
                 mView.showUnauthorizedError();
             }
 
             @Override
             public void onFailed(Throwable throwable) {
+                if (!isViewAttached()) return;
                 mView.showError(throwable.getMessage());
             }
         });
@@ -159,6 +168,7 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
         mDataManager.getStories(id, offset, limit, new RemoteCallback<DataWrapper<List<Comic>>>() {
             @Override
             public void onSuccess(DataWrapper<List<Comic>> response) {
+                if (!isViewAttached()) return;
                 mView.hideProgress();
                 if (response.getData().getResults().isEmpty()) {
                     mView.showError("Character has no stories");
@@ -169,11 +179,13 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
 
             @Override
             public void onUnauthorized() {
+                if (!isViewAttached()) return;
                 mView.showUnauthorizedError();
             }
 
             @Override
             public void onFailed(Throwable throwable) {
+                if (!isViewAttached()) return;
                 mView.showError(throwable.getMessage());
             }
         });
@@ -187,6 +199,7 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
         mDataManager.getEvents(id, offset, limit, new RemoteCallback<DataWrapper<List<Comic>>>() {
             @Override
             public void onSuccess(DataWrapper<List<Comic>> response) {
+                if (!isViewAttached()) return;
                 mView.hideProgress();
                 if (response.getData().getResults().isEmpty()) {
                     mView.showError("Character has no events");
@@ -197,11 +210,13 @@ public class CharacterPresenter extends BasePresenter<CharacterContract.Characte
 
             @Override
             public void onUnauthorized() {
+                if (!isViewAttached()) return;
                 mView.showUnauthorizedError();
             }
 
             @Override
             public void onFailed(Throwable throwable) {
+                if (!isViewAttached()) return;
                 mView.showError(throwable.getMessage());
             }
         });

--- a/core/src/main/java/com/joaquimley/core/ui/list/ListPresenter.java
+++ b/core/src/main/java/com/joaquimley/core/ui/list/ListPresenter.java
@@ -62,6 +62,7 @@ public class ListPresenter extends BasePresenter<ListContract.ListView> implemen
                 new RemoteCallback<DataWrapper<List<CharacterMarvel>>>() {
                     @Override
                     public void onSuccess(DataWrapper<List<CharacterMarvel>> response) {
+                        if (!isViewAttached()) return;
                         mView.hideProgress();
                         List<CharacterMarvel> responseResults = response.getData().getResults();
                         if (responseResults.isEmpty()) {
@@ -78,12 +79,14 @@ public class ListPresenter extends BasePresenter<ListContract.ListView> implemen
 
                     @Override
                     public void onUnauthorized() {
+                        if (!isViewAttached()) return;
                         mView.hideProgress();
                         mView.showUnauthorizedError();
                     }
 
                     @Override
                     public void onFailed(Throwable throwable) {
+                        if (!isViewAttached()) return;
                         mView.hideProgress();
                         mView.showError(throwable.getMessage());
                     }


### PR DESCRIPTION
When I leave activity before service callback returns, the app crashes due to trying to access view object in service callback methods.
