### PR TITLE
Fix memory leak on orientation change

### DIFF
--- a/mobile/src/main/java/com/joaquimley/avenging/ui/list/ListFragment.java
+++ b/mobile/src/main/java/com/joaquimley/avenging/ui/list/ListFragment.java
@@ -16,7 +16,6 @@
 
 package com.joaquimley.avenging.ui.list;
 
-import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -34,7 +33,6 @@ import android.support.v7.widget.SearchView;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.transition.Slide;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -63,7 +61,7 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     private static final int TAB_LAYOUT_ITEM_SPAN_SIZE = 1;
     private static final int SCREEN_TABLET_DP_WIDTH = 600;
 
-    private Context mActivity;
+    private AppCompatActivity mActivity;
     private ListPresenter mListPresenter;
     private ListAdapter mListCharacterAdapter;
     private String mSearchQuery;
@@ -119,8 +117,8 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     }
 
     private void initViews(View view) {
-        mActivity = getActivity().getApplicationContext();
-        ((AppCompatActivity) getActivity()).setSupportActionBar((Toolbar) view.findViewById(R.id.toolbar));
+        mActivity = (AppCompatActivity) getActivity();
+        mActivity.setSupportActionBar((Toolbar) view.findViewById(R.id.toolbar));
 
         mCharactersRecycler = (RecyclerView) view.findViewById(R.id.recycler_characters);
         mCharactersRecycler.setHasFixedSize(true);
@@ -276,7 +274,7 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     }
 
     private Bundle makeTransitionBundle(View sharedElementView) {
-        return ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
+        return ActivityOptionsCompat.makeSceneTransitionAnimation(mActivity,
                 sharedElementView, ViewCompat.getTransitionName(sharedElementView)).toBundle();
     }
 

--- a/mobile/src/main/java/com/joaquimley/avenging/ui/list/ListFragment.java
+++ b/mobile/src/main/java/com/joaquimley/avenging/ui/list/ListFragment.java
@@ -16,6 +16,7 @@
 
 package com.joaquimley.avenging.ui.list;
 
+import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
@@ -33,6 +34,7 @@ import android.support.v7.widget.SearchView;
 import android.support.v7.widget.Toolbar;
 import android.text.TextUtils;
 import android.transition.Slide;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -61,7 +63,7 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     private static final int TAB_LAYOUT_ITEM_SPAN_SIZE = 1;
     private static final int SCREEN_TABLET_DP_WIDTH = 600;
 
-    private AppCompatActivity mActivity;
+    private Context mActivity;
     private ListPresenter mListPresenter;
     private ListAdapter mListCharacterAdapter;
     private String mSearchQuery;
@@ -117,8 +119,8 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     }
 
     private void initViews(View view) {
-        mActivity = (AppCompatActivity) getActivity();
-        mActivity.setSupportActionBar((Toolbar) view.findViewById(R.id.toolbar));
+        mActivity = getActivity().getApplicationContext();
+        ((AppCompatActivity) getActivity()).setSupportActionBar((Toolbar) view.findViewById(R.id.toolbar));
 
         mCharactersRecycler = (RecyclerView) view.findViewById(R.id.recycler_characters);
         mCharactersRecycler.setHasFixedSize(true);
@@ -274,7 +276,7 @@ public class ListFragment extends Fragment implements ListContract.ListView,
     }
 
     private Bundle makeTransitionBundle(View sharedElementView) {
-        return ActivityOptionsCompat.makeSceneTransitionAnimation(mActivity,
+        return ActivityOptionsCompat.makeSceneTransitionAnimation(getActivity(),
                 sharedElementView, ViewCompat.getTransitionName(sharedElementView)).toBundle();
     }
 
@@ -313,6 +315,12 @@ public class ListFragment extends Fragment implements ListContract.ListView,
             return true;
         }
         return false;
+    }
+
+    @Override
+    public void onDestroyView() {
+        mCharactersRecycler.setAdapter(null);
+        super.onDestroyView();
     }
 
     @Override


### PR DESCRIPTION
Noticed that when orientation is changed on ListActivity several times, LeakCanary finds a memory leak. Apperantly, RecyclerView in ListFragment leaks ListActivity. When adapter is detached from RecyclerView in onDestroyView(), the memory leak is fixed.

![device-2016-11-04-010557](https://cloud.githubusercontent.com/assets/3411015/19989202/9bb5e0de-a22d-11e6-9ef0-f8d0705a1264.png)



